### PR TITLE
Proper shell quoting

### DIFF
--- a/rakudup
+++ b/rakudup
@@ -1,17 +1,16 @@
 #!/usr/bin/env bash
 # https://github.com/stmuk/rakudup
 
-RAKUDO_ROOT="${HOME}/.rakudup"
+RAKUDO_ROOT=$HOME/.rakudup
 
 set -e
 
-if [ ! -z "$DEBUG" ]
-then
-    set -x 
+if [[ $DEBUG ]]; then
+    set -x
 fi
 
-if [ ! -d ${RAKUDO_ROOT} ]; then
-    mkdir ${RAKUDO_ROOT}
+if [[ ! -d $RAKUDO_ROOT ]]; then
+    mkdir -- "$RAKUDO_ROOT"
 fi
 
 if [[ ! $(git --version) =~ ^git ]]; then
@@ -24,51 +23,51 @@ if [[ ! $(perl -v) =~ "Perl 5" ]]; then
     exit 1
 fi
 
-TMP=${RAKUDO_ROOT}/tmp
+TMP=$RAKUDO_ROOT/tmp
 
-RELEASE=$(git clone -q --no-checkout --depth 1 git@github.com:rakudo/rakudo.git ${TMP} > /dev/null 2>&1 && cd $dir && git -C ${TMP} show master:VERSION && rm -rf ${TMP})
+RELEASE=$(git clone -q --no-checkout --depth 1 git@github.com:rakudo/rakudo.git -- "$TMP" > /dev/null 2>&1 && cd -- "$dir" && git -C "$TMP" show master:VERSION && rm -rf -- "$TMP")
 
-RAKUDO_SRC="${RAKUDO_ROOT}/${RELEASE}/src"
-RAKUDO_INSTALL="${RAKUDO_ROOT}/${RELEASE}/install"
+RAKUDO_SRC="$RAKUDO_ROOT/$RELEASE/src"
+RAKUDO_INSTALL="$RAKUDO_ROOT/$RELEASE/install"
 
-if [[ -d ${RAKUDO_INSTALL} ]]; then
+if [[ -d $RAKUDO_INSTALL ]]; then
     echo "${RELEASE} already installed not updating"
     exit 1
 fi
 
-echo "Getting Rakudo ${RELEASE}"
+echo "Getting Rakudo $RELEASE"
 
 git clone -q -c advice.detachedHead=false --depth=1 -b ${RELEASE} https://github.com/rakudo/rakudo.git ${RAKUDO_SRC} 
 
-cd ${RAKUDO_SRC}
-echo "Building Rakudo ${RELEASE}. This will take several minutes on a modern CPU."
-echo "'tail -f ${RAKUDO_SRC}/build.log' for progress"
+cd -- "$RAKUDO_SRC" || exit 1
+echo "Building Rakudo $RELEASE. This will take several minutes on a modern CPU."
+echo "'tail -f -- \"$RAKUDO_SRC/build.log\"' for progress"
 
-CFLAGS="-pipe" perl Configure.pl --gen-moar --prefix=${RAKUDO_INSTALL} --make-install > ${RAKUDO_SRC}/build.log 2>&1
+CFLAGS="-pipe" perl Configure.pl --gen-moar "--prefix=$RAKUDO_INSTALL" --make-install > "$RAKUDO_SRC/build.log" 2>&1
 
 if [[ $? == 1 ]]; then
     exit $?
 fi
 
-echo "Built Rakudo ${RELEASE} OK in ${SECONDS} sec(s)"
+echo "Built Rakudo $RELEASE OK in $SECONDS sec(s)"
 
-ln -sf ${RAKUDO_INSTALL} "${RAKUDO_ROOT}/install"
+ln -sf -- "$RAKUDO_INSTALL" "$RAKUDO_ROOT/install"
 
 echo "Installing zef (module installer)"
-git clone -q --depth=1 https://github.com/ugexe/zef.git ${RAKUDO_SRC}/zef
-cd ${RAKUDO_SRC}/zef && ${RAKUDO_INSTALL}/bin/perl6 -Ilib bin/zef install .
+git clone -q --depth=1 https://github.com/ugexe/zef.git -- "$RAKUDO_SRC/zef"
+cd -- "$RAKUDO_SRC/zef" && "$RAKUDO_INSTALL/bin/perl6" -Ilib bin/zef install .
 
-if [[ ! -d "${RAKUDO_ROOT}/site" ]]; then
-    mkdir "${RAKUDO_ROOT}/site"
+if [[ ! -d "$RAKUDO_ROOT/site" ]]; then
+    mkdir -- "$RAKUDO_ROOT/site"
 fi
 
-ln -sf "${RAKUDO_INSTALL}/share/perl6/site/bin" "${RAKUDO_ROOT}/site/bin"
+ln -sf -- "$RAKUDO_INSTALL/share/perl6/site/bin" "$RAKUDO_ROOT/site/bin"
 
-ADDPATH="export PATH=${RAKUDO_ROOT}/install/bin:${RAKUDO_ROOT}/site/bin:\$PATH"
+ADDPATH="export PATH=$RAKUDO_ROOT/install/bin:$RAKUDO_ROOT/site/bin:\$PATH"
 
-if [[ -z $(grep .rakudup "${HOME}/.profile") ]]; then
-    echo ${ADDPATH} >> $HOME/.profile
-    echo "'${ADDPATH}' added to end of .profile for next login"
+if ! grep .rakudup -- "$HOME/.profile"; then
+    printf "%s\n" "$ADDPATH" >> "$HOME/.profile"
+    echo "'$ADDPATH' added to end of .profile for next login"
     echo "or use this command to take effect now"
 fi
 


### PR DESCRIPTION
To support any paths that contain spaces or start with -. Also,
removes nonsensical use of ${} because it does nothing anyway.